### PR TITLE
Containerisation of processes, and Shifter profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,26 @@ This pipeline is currently being re-written in the **Nextflow** language as a _c
 
 **2024-02-27:** The `R:4.2.0` environment (and `blast+`) is now available in a (linux/amd64) Docker image available at [Docker Hub](https://hub.docker.com/repository/docker/jackscanlan/piperline/general). Scripts are provided to run the pipeline on the BASC HPC, which uses [SLURM](https://slurm.schedmd.com/) and [Shifter](https://github.com/NERSC/shifter), in the `running_scripts` directory. 
 
-To run the pipeline in a SLURM-based HPC using `shifter`, modify the `RUN_LOC` and `RUN_DIR` variables in `basc_shifter.slurm`, and also modify the `module` commands to be specific for your system. 
+
+**2024-06-12:** To run the pipeline using containers, install [`nextflow`](https://www.nextflow.io/docs/latest/install.html) (not the `all` distribution, in order to allow third-party plugins), [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [`shifter`](https://shifter.readthedocs.io/en/latest/install_guides.html). Use the following commands to run a test dataset:
+
+    # make sure git, nextflow and shifter are all available in your path
+    
+    # clone this GitHub project to a new directory
+    git clone https://github.com/jackscanlan/piperline.git test_data && \
+        cd test_data  
+
+    # run the pipeline using nextflow v23.04.5
+    NXF_VER=23.04.5 nextflow run . --samplesheet test_data/dual/samplesheet_read_dir.csv -profile shifter
+
+
 
 #### Important notes:
 
-- Charliecloud will not work with this pipeline. It seems like Nextflow (as of version `24.04.2`) fails to handle using Charliecloud with pipelines that use more than one container, as they cannot all get pulled at the same time. Even for pipelines that use only a single container, moving the container contents to each process work directory slows the execution down considerably and increases the project footprint. 
 - This pipeline currently only works with native Shifter support (ie. with `-profile shifter` in the Nextflow run command) if Nextflow is version `23.04.5` (or possibly older). This is due to a bug in how Nextflow (at least versions `23.10.0` to `24.04.2`) sets up the process environment in `.command.run`
 - The pipeline has not been tested with Docker, Singularity, Apptainer or Podman (only Shifter). If you run the pipeline using one of these platforms, please let us know if it works or not!
+- Charliecloud has been tested and will not work with this pipeline. 
+    - It seems like Nextflow (as of version `24.04.2`) fails to handle using Charliecloud with pipelines that use more than one container, as they cannot all get pulled at the same time. Even for pipelines that use only a single container, moving the container contents to each process work directory slows the execution down considerably and increases the project footprint. 
 - When running the pipeline with containers, you must be using a Linux system with AMD64 architecture (such as AgVic's BASC). In the future, we will try to support other architectures by using multi-platform containers. 
 
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ This pipeline is currently being re-written in the **Nextflow** language as a _c
 
 To run the pipeline in a SLURM-based HPC using `shifter`, modify the `RUN_LOC` and `RUN_DIR` variables in `basc_shifter.slurm`, and also modify the `module` commands to be specific for your system. 
 
+#### Important notes:
 
-
+- Charliecloud will not work with this pipeline. It seems like Nextflow (as of version `24.04.2`) fails to handle using Charliecloud with pipelines that use more than one container, as they cannot all get pulled at the same time. Even for pipelines that use only a single container, moving the container contents to each process work directory slows the execution down considerably and increases the project footprint. 
+- This pipeline currently only works with native Shifter support (ie. with `-profile shifter` in the Nextflow run command) if Nextflow is version `23.04.5` (or possibly older). This is due to a bug in how Nextflow (at least versions `23.10.0` to `24.04.2`) sets up the process environment in `.command.run`
+- The pipeline has not been tested with Docker, Singularity, Apptainer or Podman (only Shifter). If you run the pipeline using one of these platforms, please let us know if it works or not!
+- When running the pipeline with containers, you must be using a Linux system with AMD64 architecture (such as AgVic's BASC). In the future, we will try to support other architectures by using multi-platform containers. 
 
 
 

--- a/bin/primer_trim.sh
+++ b/bin/primer_trim.sh
@@ -36,7 +36,7 @@ REV_PRIMER=${4/I/N}
 # lhist=primer_trim_lhist_${7}_${6}_${5}.txt
 
 ## trying with cutadapt (preferred)
-module load cutadapt/3.4-GCCcore-10.3.0
+# module load cutadapt/3.4-GCCcore-10.3.0
 
 # reverse complement the primer sequences
 FWD_PRIMER_RC=$(echo ${FWD_PRIMER} | \

--- a/bin/primer_trim.sh
+++ b/bin/primer_trim.sh
@@ -49,15 +49,15 @@ REV_PRIMER_RC=$(echo ${REV_PRIMER} | \
 # run cutadapt in "linked adapter" mode
 # see here: https://cutadapt.readthedocs.io/en/stable/recipes.html#trimming-amplicon-primers-from-paired-end-reads
 cutadapt \
--a ^${FWD_PRIMER}...${REV_PRIMER_RC} \
--A ^${REV_PRIMER}...${FWD_PRIMER_RC} \
---discard-untrimmed \
---rename="{header}" \
---report=minimal \
--o ${7}_${6}_${5}_trim_R1.fastq.gz \
--p ${7}_${6}_${5}_trim_R2.fastq.gz \
-${1} \
-${2}
+    -a ^${FWD_PRIMER}...${REV_PRIMER_RC} \
+    -A ^${REV_PRIMER}...${FWD_PRIMER_RC} \
+    --discard-untrimmed \
+    --rename="{header}" \
+    --report=minimal \
+    -o ${7}_${6}_${5}_trim_R1.fastq.gz \
+    -p ${7}_${6}_${5}_trim_R2.fastq.gz \
+    ${1} \
+    ${2}
 
 ## count reads in output files
 # forward reads

--- a/bin/split_loci.sh
+++ b/bin/split_loci.sh
@@ -28,7 +28,7 @@ else
     MINK_LEN=$FWD_LEN
 fi
 
-module load BBMap/38.98-GCC-11.2.0
+# module load BBMap/38.98-GCC-11.2.0
 
 bbduk.sh \
 in=${1} \

--- a/bin/split_loci.sh
+++ b/bin/split_loci.sh
@@ -31,19 +31,19 @@ fi
 # module load BBMap/38.98-GCC-11.2.0
 
 bbduk.sh \
-in=${1} \
-in2=${2} \
-literal=${FWD_PRIMER},${REV_PRIMER} \
-out=reject1.fastq.gz \
-out2=reject2.fastq.gz \
-outm=${7}_${6}_${5}_R1.fastq.gz \
-outm2=${7}_${6}_${5}_R2.fastq.gz \
-restrictleft=${KMER_LEN} \
-copyundefined=true \
-k=${MINK_LEN} \
-rcomp=t \
-stats=split_loci_stats_${7}_${6}_${5}.txt \
-lhist=split_loci_lhist_${7}_${6}_${5}.txt
+    in=${1} \
+    in2=${2} \
+    literal=${FWD_PRIMER},${REV_PRIMER} \
+    out=reject1.fastq.gz \
+    out2=reject2.fastq.gz \
+    outm=${7}_${6}_${5}_R1.fastq.gz \
+    outm2=${7}_${6}_${5}_R2.fastq.gz \
+    restrictleft=${KMER_LEN} \
+    copyundefined=true \
+    k=${MINK_LEN} \
+    rcomp=t \
+    stats=split_loci_stats_${7}_${6}_${5}.txt \
+    lhist=split_loci_lhist_${7}_${6}_${5}.txt
 
 ## count reads in input files
 # forward reads

--- a/jack_notes/.Rprofile
+++ b/jack_notes/.Rprofile
@@ -1,2 +1,4 @@
-.libPaths("~/R_libs/default")
 options(renv.config.pak.enabled = TRUE)
+
+### this should only be set if local R libraries needed, not needed with containers
+# .libPaths("~/R_libs/default")

--- a/jack_notes/nextflow_notes.md
+++ b/jack_notes/nextflow_notes.md
@@ -100,6 +100,43 @@ Running Nextflow with local version:
 
     nextflow run . -resume --samplesheet test_data/dual/samplesheet_read_dir.csv
 
+Running Nextflow with shifter testing:
+
+    module load Java/17.0.6 shifter/22.02.1
+
+    nextflow run . -resume --samplesheet test_data/dual/samplesheet_read_dir.csv
+
+Running nextflow with charliecloud testing:
+
+    module purge && module load Java/17.0.6 charliecloud/0.37-GCCcore-12.3.0
+
+    nextflow run . -resume --samplesheet test_data/dual/samplesheet_read_dir.csv
+
+Run with shifter testing old versions of Nextflow:
+
+    module load Java/17.0.6 shifter/22.02.1
+
+    # 24.04.2 (current); failed
+    NXF_VER=24.04.2 nextflow run . --samplesheet test_data/dual/samplesheet_read_dir.csv
+    # failed
+    NXF_VER=24.04.1 nextflow run . --samplesheet test_data/dual/samplesheet_read_dir.csv
+    # failed
+    NXF_VER=24.04.0 nextflow run . --samplesheet test_data/dual/samplesheet_read_dir.csv
+    # failed
+    NXF_VER=23.10.2 nextflow run . --samplesheet test_data/dual/samplesheet_read_dir.csv
+    # failed
+    NXF_VER=23.10.1 nextflow run . --samplesheet test_data/dual/samplesheet_read_dir.csv
+    # failed
+    NXF_VER=23.10.0 nextflow run . --samplesheet test_data/dual/samplesheet_read_dir.csv
+    
+
+    ## command works, but currently pipeline fails at SPLIT_LOCI due to lack of BASC modules in container
+    # .command.run no longer has the NXF_TASK_WORKDIR
+    NXF_VER=23.04.5 nextflow run . --samplesheet test_data/dual/samplesheet_read_dir.csv
+
+
+
+
 
 
 

--- a/jack_notes/nextflow_notes.md
+++ b/jack_notes/nextflow_notes.md
@@ -132,10 +132,14 @@ Run with shifter testing old versions of Nextflow:
 
     ## command works, but currently pipeline fails at SPLIT_LOCI due to lack of BASC modules in container
     # .command.run no longer has the NXF_TASK_WORKDIR
-    NXF_VER=23.04.5 nextflow run . --samplesheet test_data/dual/samplesheet_read_dir.csv
+    NXF_VER=23.04.5 nextflow run . --samplesheet test_data/dual/samplesheet_read_dir.csv -profile shifter
 
 
+Testing containers with shifter
 
+    module load shifter
+
+    
 
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,6 +37,15 @@ profiles {
     debug {
         // 
     }
+    shifter {
+        shifter.enabled        = true
+        conda.enabled          = false
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        charliecloud.enabled   = false
+        apptainer.enabled      = false
+    }
 }
 
 plugins {
@@ -73,18 +82,3 @@ executor {
     // cpus = 1 // restricts pipeline cpu use to single core (ie. no parallel processes) 
 }
 
-shifter {
-    enabled             = true
-}
-
-charliecloud {
-    enabled             = false
-    // writeFake = true
-}
-
-process {
-    
-    // withName: '!PRIMER_TRIM|SPLIT_LOCI' {
-        container       = "jackscanlan/piperline-multi:0.0.1"
-    // }
-}

--- a/nextflow.config
+++ b/nextflow.config
@@ -73,3 +73,8 @@ executor {
     // cpus = 1 // restricts pipeline cpu use to single core (ie. no parallel processes) 
 }
 
+shifter {
+    enabled             = true
+}
+
+process.container       = "jackscanlan/piperline-multi:0.0.1"

--- a/nextflow.config
+++ b/nextflow.config
@@ -77,4 +77,14 @@ shifter {
     enabled             = true
 }
 
-process.container       = "jackscanlan/piperline-multi:0.0.1"
+charliecloud {
+    enabled             = false
+    // writeFake = true
+}
+
+process {
+    
+    // withName: '!PRIMER_TRIM|SPLIT_LOCI' {
+        container       = "jackscanlan/piperline-multi:0.0.1"
+    // }
+}

--- a/nextflow/modules/assignment_plot.nf
+++ b/nextflow/modules/assignment_plot.nf
@@ -2,6 +2,7 @@ process ASSIGNMENT_PLOT {
     def module_name = "assignment_plot"
     tag "$pcr_primers; $fcid"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(pcr_primers), val(fcid), path(seqtab), path(blast), path(tax), val(loci_params)

--- a/nextflow/modules/dada_mergereads.nf
+++ b/nextflow/modules/dada_mergereads.nf
@@ -2,6 +2,7 @@ process DADA_MERGEREADS {
     def module_name = "dada_mergereads"
     tag "$pcr_primers; $fcid"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(pcr_primers), val(fcid), val(concat_unmerged), val(meta), path(readsF), path(readsR), path(seqsF), path(seqsR)

--- a/nextflow/modules/dada_priors.nf
+++ b/nextflow/modules/dada_priors.nf
@@ -2,6 +2,7 @@ process DADA_PRIORS {
     def module_name = "dada_priors"
     tag "$pcr_primers; $fcid"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(direction), val(pcr_primers), val(fcid), path(priors)

--- a/nextflow/modules/denoise.nf
+++ b/nextflow/modules/denoise.nf
@@ -2,6 +2,7 @@ process DENOISE {
     def module_name = "denoise"
     tag "$pcr_primers; $meta.sample_id"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(direction), val(pcr_primers), val(fcid), val(meta), path(reads), path(errormodel), path(priors)

--- a/nextflow/modules/error_model.nf
+++ b/nextflow/modules/error_model.nf
@@ -2,6 +2,7 @@ process ERROR_MODEL {
     def module_name = "error_model"
     tag "$pcr_primers; $fcid"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(direction), val(pcr_primers), val(fcid), path(reads)

--- a/nextflow/modules/filter_qualplots.nf
+++ b/nextflow/modules/filter_qualplots.nf
@@ -2,6 +2,7 @@ process FILTER_QUALPLOTS {
     def module_name = "filter_qualplots"
     tag "$meta.fcid; $meta.sample_id"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(meta), path(reads)

--- a/nextflow/modules/filter_qualplots_combine.nf
+++ b/nextflow/modules/filter_qualplots_combine.nf
@@ -2,6 +2,7 @@ process FILTER_QUALPLOTS_COMBINE {
     def module_name = "filter_qualplots_combine"
     tag "Whole pipeline" 
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
 

--- a/nextflow/modules/filter_seqtab.nf
+++ b/nextflow/modules/filter_seqtab.nf
@@ -2,6 +2,7 @@ process FILTER_SEQTAB {
     def module_name = "filter_seqtab"
     tag "$pcr_primers; $fcid"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(pcr_primers), val(fcid), val(meta), path(seqtab)

--- a/nextflow/modules/joint_tax.nf
+++ b/nextflow/modules/joint_tax.nf
@@ -2,6 +2,7 @@ process JOINT_TAX {
     def module_name = "joint_tax"
     tag "$pcr_primers; $fcid"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(pcr_primers), val(fcid), path(tax), path(blast), path(seqtab), val(loci_params)

--- a/nextflow/modules/merge_tax.nf
+++ b/nextflow/modules/merge_tax.nf
@@ -2,6 +2,7 @@ process MERGE_TAX {
     def module_name = "merge_tax"
     tag "$pcr_primers"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(pcr_primers), val(fcid), path(taxtab)

--- a/nextflow/modules/parameter_setup.nf
+++ b/nextflow/modules/parameter_setup.nf
@@ -2,6 +2,7 @@ process PARAMETER_SETUP {
     def module_name = "parameter_setup"
     tag "Whole dataset"
     // label: 
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
 

--- a/nextflow/modules/parse_inputs.nf
+++ b/nextflow/modules/parse_inputs.nf
@@ -2,6 +2,7 @@ process PARSE_INPUTS {
     def module_name = "parse_inputs"
     tag "Whole dataset"
     // label 
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     val(samplesheet)

--- a/nextflow/modules/phyloseq_filter.nf
+++ b/nextflow/modules/phyloseq_filter.nf
@@ -2,6 +2,7 @@ process PHYLOSEQ_FILTER {
     def module_name = "phyloseq_filter"
     tag "$pcr_primers"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(pcr_primers), path(ps), val(loci_params)

--- a/nextflow/modules/phyloseq_merge.nf
+++ b/nextflow/modules/phyloseq_merge.nf
@@ -2,6 +2,7 @@ process PHYLOSEQ_MERGE {
     def module_name = "phyloseq_merge"
     tag "Whole dataset"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     path(ps_unfiltered)

--- a/nextflow/modules/phyloseq_unfiltered.nf
+++ b/nextflow/modules/phyloseq_unfiltered.nf
@@ -2,6 +2,7 @@ process PHYLOSEQ_UNFILTERED {
     def module_name = "phyloseq_unfiltered"
     tag "$pcr_primers"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(pcr_primers), path(taxtab), path(seqtab_list), path(samdf_locus), val(loci_params)

--- a/nextflow/modules/primer_trim.nf
+++ b/nextflow/modules/primer_trim.nf
@@ -2,7 +2,8 @@ process PRIMER_TRIM {
     def module_name = "primer_trim"
     tag "$meta.pcr_primers; $meta.sample_id"
     // label
-    container "pegi3s/cutadapt:latest"
+    // container "pegi3s/cutadapt:latest"
+    container "thatdnaguy/cutadapt:v4.7_02"
 
     input:
     // input read pairs, primer seqs and locus name (to use in output file names)

--- a/nextflow/modules/primer_trim.nf
+++ b/nextflow/modules/primer_trim.nf
@@ -1,7 +1,8 @@
 process PRIMER_TRIM {
     def module_name = "primer_trim"
     tag "$meta.pcr_primers; $meta.sample_id"
-    // label:  
+    // label
+    container "pegi3s/cutadapt:latest"
 
     input:
     // input read pairs, primer seqs and locus name (to use in output file names)
@@ -18,7 +19,7 @@ process PRIMER_TRIM {
     script:
     def module_script = "${module_name}.sh"
     """
-    #!/usr/bin/bash
+    #!/bin/bash
 
     ### run module code
     bash ${module_name}.sh \

--- a/nextflow/modules/primer_trim_r.nf
+++ b/nextflow/modules/primer_trim_r.nf
@@ -2,6 +2,7 @@ process PRIMER_TRIM_R {
     def module_name = "primer_trim_r"
     // tag: 
     // label: 
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(meta), path(reads)

--- a/nextflow/modules/read_filter.nf
+++ b/nextflow/modules/read_filter.nf
@@ -2,6 +2,7 @@ process READ_FILTER {
     def module_name = "read_filter"
     tag "$meta.pcr_primers; $meta.sample_id"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(meta), path(reads)

--- a/nextflow/modules/read_tracking.nf
+++ b/nextflow/modules/read_tracking.nf
@@ -1,8 +1,9 @@
 process READ_TRACKING {
     def module_name = "read_tracking"
     tag "Whole dataset"
-    // label:  
+    // label  
     // cache false 
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     path(rt_samples)

--- a/nextflow/modules/seq_qc.nf
+++ b/nextflow/modules/seq_qc.nf
@@ -1,7 +1,8 @@
 process SEQ_QC {
     def module_name = "seq_qc"
     tag "$fcid"
-    // label: 
+    // label
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     val(fcid) 

--- a/nextflow/modules/split_loci.nf
+++ b/nextflow/modules/split_loci.nf
@@ -1,7 +1,8 @@
 process SPLIT_LOCI {
     def module_name = "split_loci"
     tag "$meta.pcr_primers; $meta.sample_id"
-    // label:  
+    // label
+    container "nanozoo/bbmap:38.86--9ebcbfa"
 
     input:
     tuple val(meta), path(reads)
@@ -19,7 +20,7 @@ process SPLIT_LOCI {
     script:
     def module_script = "${module_name}.sh"
     """
-    #!/usr/bin/bash
+    #!/bin/bash
 
     ### run module code
     bash ${module_name}.sh \

--- a/nextflow/modules/tax_blast.nf
+++ b/nextflow/modules/tax_blast.nf
@@ -2,6 +2,7 @@ process TAX_BLAST {
     def module_name = "tax_blast"
     tag "$pcr_primers; $fcid"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(pcr_primers), val(fcid), val(meta), path(seqtab)

--- a/nextflow/modules/tax_idtaxa.nf
+++ b/nextflow/modules/tax_idtaxa.nf
@@ -1,7 +1,8 @@
 process TAX_IDTAXA {
     def module_name = "tax_idtaxa"
     tag "$pcr_primers; $fcid"
-    // label:  
+    // label
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(pcr_primers), val(fcid), val(meta), path(seqtab)

--- a/nextflow/modules/tax_summary.nf
+++ b/nextflow/modules/tax_summary.nf
@@ -2,6 +2,7 @@ process TAX_SUMMARY {
     def module_name = "tax_summary"
     tag "$pcr_primers; $fcid"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     tuple val(pcr_primers), val(fcid), path(tax), path(ids), path(joint), val(loci_params)

--- a/nextflow/modules/tax_summary_merge.nf
+++ b/nextflow/modules/tax_summary_merge.nf
@@ -2,6 +2,7 @@ process TAX_SUMMARY_MERGE {
     def module_name = "tax_summary_merge"
     tag "Whole dataset"
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     path(tax_summary_list)

--- a/nextflow/modules/template.nf
+++ b/nextflow/modules/template.nf
@@ -1,7 +1,6 @@
 process TEMPLATE {
     def module_name = "template"
-
-    // tag 
+    tag "Whole dataset"
     // label 
 
     input:

--- a/nextflow/modules/template_rscript.nf
+++ b/nextflow/modules/template_rscript.nf
@@ -2,6 +2,7 @@ process TEMPLATE_RSCRIPT {
     def module_name = "template_rscript"
     // tag: 
     // label:  
+    container "jackscanlan/piperline-multi:0.0.1"
 
     input:
     val input


### PR DESCRIPTION
Containers are now used for every process. 

The profile 'shifter' can now be used to run containers through the Shifter container platform. Other container platform software, such as Docker, Apptainer, Singularity and Podman (but not Charliecloud), may also work, but this has not been tested. Profiles for non-Shifter software have not been set up.

Note: containers with Shifter currently only work if Nextflow is version 23.04.5, due to a recent bug. 