### PR TITLE
Fixing BLAST and IDTAXA species incompatibilities

### DIFF
--- a/bin/joint_tax.R
+++ b/bin/joint_tax.R
@@ -42,10 +42,10 @@ blast_output <-
     dplyr::bind_rows()
 
 # Normalise the delimiter in the blast spp output to what is used by idtaxa
-if(any(str_detect(idtaxa_output$Species, "_"), na.rm = TRUE) & !any(str_detect(idtaxa_output$Species, "_"), na.rm = TRUE)){
-  blast_output$blast_spp <- stringr::str_replace_all(" ", "_")
-} else if(any(str_detect(idtaxa_output$Species, " "), na.rm = TRUE) & !any(str_detect(idtaxa_output$Species, "_"), na.rm = TRUE)){
-  blast_output$blast_spp <- stringr::str_replace_all("_", " ")
+if(any(stringr::str_detect(idtaxa_output$Species, "_"), na.rm = TRUE) & !any(stringr::str_detect(idtaxa_output$Species, "_"), na.rm = TRUE)){
+  blast_output$blast_spp <- stringr::str_replace_all(blast_output$blast_spp, " ", "_")
+} else if(any(str_detect(idtaxa_output$Species, " "), na.rm = TRUE) & !any(stringr::str_detect(idtaxa_output$Species, "_"), na.rm = TRUE)){
+  blast_output$blast_spp <- stringr::str_replace_all(blast_output$blast_spp, "_", " ")
 }
 
 # check that BLAST ASVs are those in IDTAXA ASVs

--- a/bin/joint_tax.R
+++ b/bin/joint_tax.R
@@ -42,10 +42,10 @@ blast_output <-
     dplyr::bind_rows()
 
 # Normalise the delimiter in the blast spp output to what is used by idtaxa
-if(any(str_detect(idtaxa_output$Species, "_"), na.rm = TRUE) & !any(str_detect(idtaxa_output$Species, "_"), na.rm = TRUE)){
-  blast_output$blast_spp <- stringr::str_replace_all(" ", "_")
-} else if(any(str_detect(idtaxa_output$Species, " "), na.rm = TRUE) & !any(str_detect(idtaxa_output$Species, "_"), na.rm = TRUE)){
-  blast_output$blast_spp <- stringr::str_replace_all("_", " ")
+if(any(stringr::str_detect(idtaxa_output$Species, "_"), na.rm = TRUE) & !any(stringr::str_detect(idtaxa_output$Species, " "), na.rm = TRUE)){
+  blast_output$blast_spp <- stringr::str_replace_all(blast_output$blast_spp, " ", "_")
+} else if(any(str_detect(idtaxa_output$Species, " "), na.rm = TRUE) & !any(stringr::str_detect(idtaxa_output$Species, "_"), na.rm = TRUE)){
+  blast_output$blast_spp <- stringr::str_replace_all(blast_output$blast_spp, "_", " ")
 }
 
 # check that BLAST ASVs are those in IDTAXA ASVs

--- a/bin/joint_tax.R
+++ b/bin/joint_tax.R
@@ -41,6 +41,13 @@ blast_output <-
     purrr::keep(., ~ nrow(.x) > 0) %>% # remove tibbles with 0 rows
     dplyr::bind_rows()
 
+# Normalise the delimiter in the blast spp output to what is used by idtaxa
+if(any(str_detect(idtaxa_output$Species, "_"), na.rm = TRUE) & !any(str_detect(idtaxa_output$Species, "_"), na.rm = TRUE)){
+  blast_output$blast_spp <- stringr::str_replace_all(" ", "_")
+} else if(any(str_detect(idtaxa_output$Species, " "), na.rm = TRUE) & !any(str_detect(idtaxa_output$Species, "_"), na.rm = TRUE)){
+  blast_output$blast_spp <- stringr::str_replace_all("_", " ")
+}
+
 # check that BLAST ASVs are those in IDTAXA ASVs
 if(!all(blast_output$seq_name %in% idtaxa_output$seq_name)){
     stop("ASV names in BLAST output don't match those in IDTAXA output")
@@ -66,7 +73,8 @@ if(nrow(idtaxa_output) > 0 & nrow(blast_output) > 0){
                 is.na(Species) & is.na(blast_spp) ~ "both_NA",
                 is.na(Species) & (!is.na(blast_spp)) ~ "idtaxa_NA",
                 (!is.na(Species)) & is.na(blast_spp) ~ "blast_NA",
-                Species == blast_spp ~ "yes"
+                Species == blast_spp ~ "both_species_match",
+                !is.na(Species) & !is.na(blast_spp) ~ "both_species_mismatch",
             )
         ) %>%
         # replace species assignment with BLAST assignment if species_match == "idtaxa_NA"

--- a/bin/tax_blast.R
+++ b/bin/tax_blast.R
@@ -107,10 +107,12 @@ if (isTRUE(run_blast)) { # run BLAST if requested
             dplyr::filter(pident >= identity, qcovs >= coverage) %>% 
             dplyr::group_by(qseqid) %>%
             # add end of species binomial
-            dplyr::mutate(spp = Species %>% stringr::str_remove("^.* ")) %>%
+            dplyr::mutate(spp = Species %>%
+                            stringr::str_remove("^.* ") %>%
+                            stringr::str_remove("^.*_")) %>%
             # create "/" for species name when multiple are best hits for one species, remove old Species name
             dplyr::reframe(spp = paste(sort(unique(spp)), collapse = "/"), Genus, pident, qcovs, max_score, total_score, evalue) %>%
-            # create new binomial
+            # create new binomial if its not present already
             dplyr::mutate(binomial = paste(Genus, spp)) %>%
             # remove duplicate IDs for the same sequence
             dplyr::distinct() %>%


### PR DESCRIPTION

- Resolved #93
- Fixed BLAST species assignments having duplicated genus names
- Fixed cases where BLAST species assignments have space delimiter, while IDTAXA has underscore, causing duplication